### PR TITLE
Fix "Collision info missing" in mods/default/item_entity.lua

### DIFF
--- a/mods/default/item_entity.lua
+++ b/mods/default/item_entity.lua
@@ -39,8 +39,8 @@ local item = {
 		})
 	end,
 
-	on_step = function(self, dtime)
-		builtin_item.on_step(self, dtime)
+	on_step = function(self, dtime, moveresult)
+		builtin_item.on_step(self, dtime, moveresult)
 
 		if self.flammable then
 			-- flammable, check for igniters


### PR DESCRIPTION
Fixes #19 

Line 43 ( https://github.com/lefty-studios/water_game/blob/master/mods/default/item_entity.lua#L43 ) calls builtin/game/item_entity.lua, Line 155 ( https://github.com/minetest/minetest/blob/master/builtin/game/item_entity.lua#L155 ). Because the call does not include the `moveresult` parameter, `moveresult` is empty and triggers the assert error on Line 199 of the called file ( https://github.com/minetest/minetest/blob/master/builtin/game/item_entity.lua#L199 ).

The fix merely adds the `moveresult` parameter to the `on_step` function signature on Line 42, and then uses it in the function call on Line 43 (i.e. referenced in the error message).

In my testing, this appears to resolve the error with no apparent drawbacks.